### PR TITLE
Fix Valiona/Theralion

### DIFF
--- a/src/server/scripts/EasternKingdoms/BastionOfTwilight/boss_valiona_theralion.cpp
+++ b/src/server/scripts/EasternKingdoms/BastionOfTwilight/boss_valiona_theralion.cpp
@@ -743,7 +743,7 @@ public:
 
             uiDazzlingDestructionCount = 0;
 
-            if (Creature* Valiona = me->FindNearestCreature(NPC_VALIONA_BOT, 500.0f, true))
+            if (Creature* Valiona = me->FindNearestCreature(NPC_VALIONA_BOT, 3000.0f, true))
                 if(Valiona && !Valiona->isInCombat())
                     Valiona->AI()->AttackStart(me->GetVictim());
 
@@ -838,7 +838,7 @@ public:
             if (instance)
                 instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me); // Remove
 
-            if (Creature* Valiona = me->FindNearestCreature(NPC_VALIONA_BOT, 500.0f, true))
+            if (Creature* Valiona = me->FindNearestCreature(NPC_VALIONA_BOT, 3000.0f, true))
                 Valiona->Kill(Valiona);
 
             _JustDied();


### PR DESCRIPTION
The problem here was the distance.:
If a rogue gets close to Valiona thanks to vanish and starts the fight
against her, Valiona won't attract Theralion to the fight
